### PR TITLE
add test for array consisting of one promise

### DIFF
--- a/test.js
+++ b/test.js
@@ -34,6 +34,17 @@ test('run array of promises sequentially', function (t) {
     })
 })
 
+test('run array consisting of only one promise', function (t) {
+  t.plan(1)
+
+  return promiseWaterfall([
+    addOne
+  ])
+  .then(function (sum) {
+    t.equals(sum, 1)
+  })
+})
+
 test('reject array', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
This adds a test for the case you only pass one promise into the waterfall.

I know, it does not make much sense to pass in only one promise, but in this case I think
of dynamically  adding promise functions into the waterfall.

Great module btw. :+1: 
