### PR TITLE
Resolve empty arrays.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,7 @@
 
 module.exports = function promiseWaterfall (callbacks) {
   // Don't assume we're running in an environment with promises
-  var first = callbacks[0]()
-  return callbacks.slice(1).reduce(function (accumulator, callback) {
+  return callbacks.reduce(function (accumulator, callback) {
     return accumulator.then(callback)
-  }, first)
+  }, Promise.resolve())
 }

--- a/test.js
+++ b/test.js
@@ -34,6 +34,16 @@ test('run array of promises sequentially', function (t) {
     })
 })
 
+test('run array consisting of zero promises', function (t) {
+  t.plan(1)
+
+  return promiseWaterfall([
+  ])
+  .then(function (result) {
+    t.equals(result, undefined)
+  })
+})
+
 test('run array consisting of only one promise', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
This provides the more intuitive behavior of resolving an empty array to `undefined`, instead of throwing an error.

Fixes #6. 